### PR TITLE
Fix bug that was causing `to-json` to always return nil

### DIFF
--- a/src/rama/client.clj
+++ b/src/rama/client.clj
@@ -60,7 +60,7 @@
    ;=> {\"a\":\"value\",\"b\":123}
    "
   [data & {:keys [pretty] :or {pretty false}}]
-  (when
+  (when data
     (-> data
         (json/generate-string {:pretty pretty :date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"})
         ((fn [s] (if pretty (str s \newline) s))))))

--- a/test/rama/client_test.clj
+++ b/test/rama/client_test.clj
@@ -1,0 +1,17 @@
+(ns rama.client-test
+  (:require [rama.client :refer :all]
+            [clojure.test :refer :all])
+  (:import [java.util Date TimeZone]))
+
+(TimeZone/setDefault (TimeZone/getTimeZone "GMT+0"))
+
+(deftest to-json-test
+  (is (= "{\"foo\":\"bar\"}"
+         (to-json {:foo :bar})))
+
+  (is (nil? (to-json nil)))
+
+  (is (= "[]" (to-json [])))
+
+  (is (= "{\"date\":\"2017-01-01T00:00:00.000Z\"}"
+         (to-json {:date (Date. (- 2017 1900) 0 1 0 0 0)}))))


### PR DESCRIPTION
The function was using the result as condition for `when`, with a empty body, so
it always returned nil.

Added some tests as well.